### PR TITLE
fix typo and order of hspec tests

### DIFF
--- a/markdown/en/tutorial.md
+++ b/markdown/en/tutorial.md
@@ -147,10 +147,10 @@ spec = do
     describe "decode" $ do
         it "decodes no padding" $
             decode "bm8tcGFkZGluZyEh" `shouldBe` "no-padding!!"
-        it "dncodes one padding" $
-            decode "cGFkZGluZyAgMg==" `shouldBe` "padding  2"
-        it "encodes two paddings" $
+        it "decodes one padding" $
             decode "cGFkZGluZzE=" `shouldBe` "padding1"
+        it "decodes two paddings" $
+            decode "cGFkZGluZyAgMg==" `shouldBe` "padding  2"
 ```
 
 As you can see,

--- a/markdown/ja/tutorial.md
+++ b/markdown/ja/tutorial.md
@@ -117,10 +117,10 @@ spec = do
      describe "decode" $ do
         it "decodes no padding" $
             decode "bm8tcGFkZGluZyEh" `shouldBe` "no-padding!!"
-        it "dncodes one padding" $
-            decode "cGFkZGluZyAgMg==" `shouldBe` "padding  2"
-        it "encodes two paddings" $
+        it "decodes one padding" $
             decode "cGFkZGluZzE=" `shouldBe` "padding1"
+        it "decodes two paddings" $
+            decode "cGFkZGluZyAgMg==" `shouldBe` "padding  2"
 ```
 
 このように hspec では、`shouldBe` など分かり易い単語を使って、テストケースを楽しく書けます。この「楽しい」という感覚がとても大事です。

--- a/test/Base64Spec.hs
+++ b/test/Base64Spec.hs
@@ -43,10 +43,10 @@ spec = do
     describe "decode" $ do
         it "decodes no padding" $
             decode "bm8tcGFkZGluZyEh" `shouldBe` "no-padding!!"
-        it "dncodes one padding" $
-            decode "cGFkZGluZyAgMg==" `shouldBe` "padding  2"
-        it "encodes two paddings" $
+        it "decodes one padding" $
             decode "cGFkZGluZzE=" `shouldBe` "padding1"
+        it "decodes two paddings" $
+            decode "cGFkZGluZyAgMg==" `shouldBe` "padding  2"
 
         prop "reverses encoded string" $ \xs ->
             decode (encode xs) == xs


### PR DESCRIPTION
- fix minor typos
- match test description to what's tested
