### PR TITLE
fix small spelling error in tutorial

### DIFF
--- a/markdown/ja/tutorial.md
+++ b/markdown/ja/tutorial.md
@@ -138,8 +138,8 @@ Spec は、hspec 関数で実行できます。
     
     decode
       - decodes no padding
-      - dncodes one padding
-      - encodes two paddings
+      - decodes one padding
+      - decodes two paddings
     
     Finished in 0.0956 seconds
     6 examples, 0 failures


### PR DESCRIPTION
Fix a small spelling error in one of the examples.