### PR TITLE
Fixed typo

### DIFF
--- a/markdown/en/tutorial.md
+++ b/markdown/en/tutorial.md
@@ -247,7 +247,7 @@ If you store test files in the same directory of source code,
 you have to repeat the dependencies of your library here.
 
 For doctest,
-"test/doctest.hs" should be created in addition to the Cabal file:
+"test/doctests.hs" should be created in addition to the Cabal file:
 
 ```haskell
 module Main where


### PR DESCRIPTION
I believe the file should be named `test/doctests.hs` rather than `test/doctest.hs`.
